### PR TITLE
Add support for pre-built instance docker images

### DIFF
--- a/scripts/build_instance_image.py
+++ b/scripts/build_instance_image.py
@@ -1,0 +1,121 @@
+"""Build a single SWE-PolyBench instance Docker image.
+
+This script handles the Docker image building process for a single instance,
+including base image creation and instance-specific image building.
+"""
+
+import sys
+import json
+import argparse
+from pathlib import Path
+
+import docker
+
+from poly_bench_evaluation.docker_utils import DockerManager
+from poly_bench_evaluation.repo_utils import RepoManager
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Build a single SWE-PolyBench instance Docker image"
+    )
+    parser.add_argument(
+        "instance_id",
+        help="Instance ID for the image"
+    )
+    parser.add_argument(
+        "language", 
+        help="Programming language (Java, JavaScript, TypeScript, Python)"
+    )
+    parser.add_argument(
+        "repo",
+        help="Repository name (e.g., google/gson)"
+    )
+    parser.add_argument(
+        "base_commit",
+        help="Base commit hash to checkout"
+    )
+    parser.add_argument(
+        "dockerfile",
+        help="Dockerfile content as string"
+    )
+    parser.add_argument(
+        "repo_path",
+        help="Base path for repository cloning"
+    )
+    
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    
+    instance_id = args.instance_id
+    language = args.language
+    repo = args.repo
+    base_commit = args.base_commit
+    dockerfile = args.dockerfile
+    repo_path = args.repo_path
+    
+    try:
+        # Create docker client
+        client = docker.from_env(timeout=720)
+        
+        # Build base image if needed (non-Python languages)
+        if language != "Python":
+            base_image_id = f"polybench_{language.lower()}_base"
+            base_docker_manager = DockerManager(image_id=base_image_id, delete_image=False, client=client)
+            
+            # Check if base image exists, build if not
+            if not base_docker_manager.check_image_local(local_image_name=base_image_id):
+                print(f"Building base image for {language}...")
+                base_docker_manager.build_base_image(language=language)
+            else:
+                print(f"Base image for {language} already exists")
+        
+        # Build instance image
+        image_id = f"polybench_{language.lower()}_{instance_id.lower()}"
+        docker_manager = DockerManager(image_id=image_id, delete_image=False, client=client)
+        
+        # Check if image already exists locally
+        if docker_manager.check_image_local(local_image_name=image_id):
+            print(f"Image {image_id} already exists locally")
+            return 0
+        
+        print(f"Cloning repository {repo} and checking out {base_commit[:8]}...")
+        
+        # Clone repo and checkout commit
+        repo_manager = RepoManager(repo_name=repo, repo_path=repo_path)
+        repo_manager.clone_repo()
+        repo_manager.checkout_commit(commit_hash=base_commit)
+        
+        print(f"Building Docker image {image_id}...")
+        
+        # Build docker image
+        build_success = docker_manager.docker_build(
+            repo_path=repo_manager.tmp_repo_dir,
+            dockerfile_content=dockerfile
+        )
+        
+        # Clean up repo manager
+        repo_manager.__del__()
+        
+        if build_success != 0:
+            print(f"Failed to build image for {instance_id}")
+            # Print build logs for debugging
+            if docker_manager.build_logs:
+                print("Build logs:")
+                for log in docker_manager.build_logs[-10:]:  # Last 10 lines
+                    print(f"  {log}")
+            return 1
+        
+        print(f"Successfully built image {image_id}")
+        return 0
+        
+    except Exception as e:
+        print(f"Error building image for {instance_id}: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/load_dataset.py
+++ b/scripts/load_dataset.py
@@ -1,0 +1,68 @@
+"""Load SWE-PolyBench dataset and output as JSON lines.
+
+This script loads the dataset from either a CSV file or HuggingFace
+and outputs each instance as a JSON line for processing by the bash script.
+"""
+
+import sys
+import argparse
+import pandas as pd
+from datasets import load_dataset
+import json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Load SWE-PolyBench dataset and output as JSON lines")
+    parser.add_argument("dataset_path", help="HuggingFace dataset name")
+    parser.add_argument("--limit", "-l", type=int, help="Limit number of instances to output (for testing)")
+    parser.add_argument("--offset", "-o", type=int, default=0, help="Skip first N instances (for resuming uploads)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    
+    dataset_path = args.dataset_path
+    limit = args.limit
+    offset = args.offset
+    
+    try:
+        # Load dataset based on file extension
+        if dataset_path.endswith('.csv'):
+            print(f"Loading CSV dataset from {dataset_path}...", file=sys.stderr)
+            df = pd.read_csv(dataset_path)
+        else:
+            print(f"Loading HuggingFace dataset from {dataset_path}...", file=sys.stderr)
+            df = load_dataset(dataset_path, split="test").to_pandas()
+        
+        print(f"Loaded {len(df)} instances", file=sys.stderr)
+        
+        # Apply offset if specified
+        if offset and offset > 0:
+            df = df.iloc[offset:]
+            print(f"Skipped first {offset} instances, {len(df)} remaining", file=sys.stderr)
+        
+        # Apply limit if specified
+        if limit and limit > 0:
+            df = df.head(limit)
+            print(f"Limited to {len(df)} instances", file=sys.stderr)
+        
+        # Verify required columns exist
+        required_columns = ['instance_id', 'language', 'repo', 'base_commit', 'Dockerfile']
+        missing_columns = [col for col in required_columns if col not in df.columns]
+        
+        if missing_columns:
+            print(f"Error: Missing required columns: {missing_columns}", file=sys.stderr)
+            sys.exit(1)
+        
+        # Output each row as JSON
+        for _, row in df.iterrows():
+            print(json.dumps(row.to_dict()))
+        
+    except Exception as e:
+        print(f"Error loading dataset: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
*Description of changes:* This PR adds support for pre-built per-instance docker images, hosted on GHCR.

*Detail:*
* Adds a script that was used to build and upload the images
* Updates the evaluation harness get an appropriate image by: 
  1. Checking for an existing local image for the instance
  2. Attempting to pull a pre-built image from `ghcr.io/timesler/swe-polybench.eval.x86_64.{instance_id}:latest`
  3. Fallback to current local docker image build solution
* No changes have been made to the usage of the harness

The changes to the actual harness code are minimal, and relate only to checking for and using a prebuilt image if it exists.

*State of pre-built images:*
* Currently, the first half (approx) of PB500 has been pushed and is available
* Should have the remaining images ready in the next few days

*Testing:*
* I have run the harness with the Gold patches successfully on the first ~150 or so instances in the dataset using prebuilt images, and will complete the evaluation over the next few days as the additional images are push and made available

*Backward compatability:*
The way this change has been implemented, it will work whether an instance has a pre-built image available or not, so can be used as is today.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
