### PR TITLE
Add dockerfile patch fixes to upload script

### DIFF
--- a/src/poly_bench_evaluation/docker_utils.py
+++ b/src/poly_bench_evaluation/docker_utils.py
@@ -47,7 +47,7 @@ class DockerManager:
         Returns:
             bool: True if image was successfully pulled, False otherwise
         """
-        ghcr_image_name = f"ghcr.io/timesler/swe-polybench.eval.x86_64.{instance_id}:{version}"
+        ghcr_image_name = f"ghcr.io/timesler/swe-polybench.eval.x86_64.{instance_id.lower()}:{version}"
         
         try:
             logger.info(f"Attempting to pull pre-built image: {ghcr_image_name}")


### PR DESCRIPTION
*Description of changes:* Added Dockerfile fixes for a series of instance that were failing to build. This included 4 classes of problems:
* Debian buster-based images: Buster has reached EOL and so `apt install` statements would fail without updating the package repo config (22 instances)
* HuggingFace model pre-downloads: Failing because the transformers repo was not adding the "https://huggingface.co" prefix for some reason (2 instances)
* Transformers broken PyAV dependency: PyAV 0.9.2 would not compile (13 instances)
* Langchain poetry version: Some langchain instances had a pyproject that was not compatible with the latest version of poetry, so had to fix an older version (3 instances)

Good news is, this probably only needs to be done once. Now that all the prebuilt images are published, they should work forever.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
