### PR TITLE
Add --repair-native-imports flag for non-AVX-512 hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The main file to run is `src/poly_bench_evaluation/run_evaluation.py`. These are
 - `--skip-existing`: Whether to skip existing evaluations in `result-path`. If set to true, the instances that are available in result-path already will be skipped.
 - `--metrics-only` : This flag, when set will only compute the file retrieval metrics and the pass rate will not be computed. Typically this flag may be used after the pass rates are computed.
 - `--node-metrics`: If you also want to compute node retrieval metrics (this will increase time of running evaluation)
+- `--repair-native-imports [PACKAGE ...]`: Rebuild listed Python packages from source inside each container if they fail to import. Use this when the pre-built images ship CPU-specific wheels that crash with `Illegal instruction` on your host (e.g. AVX-512 `hnswlib` on a non-AVX-512 CPU). Pass with no arguments to use the default list (`hnswlib`, `chroma-hnswlib`) or specify packages explicitly, e.g. `--repair-native-imports hnswlib faiss-cpu`.
 
 ## Docker images
 We have frozen the instance level docker images and uploaded them to GHCR. Please only use the GHCR docker images (instance level). They are public and can be easily pulled separately. If you run the code as is, it will automatically pull from GHCR so you do not need to do anything else. If you need specific docker images for research purpose, they can be pulled like this:

--- a/src/poly_bench_evaluation/docker_utils.py
+++ b/src/poly_bench_evaluation/docker_utils.py
@@ -131,6 +131,52 @@ class DockerManager:
         assert self.container is not None, "Container not created"
         self.container.start()
 
+    def repair_native_imports(self, packages: List[str]) -> None:
+        """Rebuild native Python wheels that fail to import on this host.
+
+        Pre-built images may ship CPU-specific wheels (e.g. an AVX-512
+        ``hnswlib``) that ``SIGILL`` on hosts without those instructions. For
+        each package in ``packages`` that is installed in the container, probe
+        the import and reinstall from source if it fails.
+        """
+        assert self.container is not None, "Container not created"
+
+        broken: List[str] = []
+        for pkg in packages:
+            installed = self.container.exec_run(
+                ["bash", "-c", f"pip show {pkg} >/dev/null 2>&1"], user="root"
+            )
+            if installed.exit_code != 0:
+                continue
+            import_name = pkg.replace("-", "_")
+            probe = self.container.exec_run(
+                ["bash", "-c", f"python -c 'import {import_name}'"], user="root"
+            )
+            if probe.exit_code != 0:
+                broken.append(pkg)
+
+        if not broken:
+            return
+
+        no_binary = ",".join(broken)
+        targets = " ".join(broken)
+        logger.info(f"Rebuilding native packages from source: {broken}")
+        result = self.container.exec_run(
+            [
+                "bash",
+                "-c",
+                f"pip install --no-binary={no_binary} --force-reinstall --quiet {targets}",
+            ],
+            user="root",
+        )
+        if result.exit_code != 0:
+            logger.warning(
+                f"Failed to rebuild native packages {broken}: "
+                f"{result.output.decode(errors='replace')[-500:]}"
+            )
+        else:
+            self.run_logs.append(f"Rebuilt native packages from source: {broken}")
+
     def copy_file_to_container(
         self, content: str, container_filename: str, target_path: str
     ) -> bool:

--- a/src/poly_bench_evaluation/run_evaluation.py
+++ b/src/poly_bench_evaluation/run_evaluation.py
@@ -5,7 +5,7 @@ import argparse
 import importlib
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Union
+from typing import List, Optional, Union
 import json
 import sys
 import docker
@@ -44,6 +44,7 @@ def evaluate_instance(
     client: docker.DockerClient,
     retrieval_metrics_only: bool = False,
     node_retrieval_metrics: bool = False,
+    repair_native_packages: Optional[List[str]] = None,
 ):
     """Instance level evaluation function.
     Args:
@@ -55,6 +56,9 @@ def evaluate_instance(
         client: The docker client
         retrieval_metrics_only: Whether to only compute retrieval metrics.
         node_retrieval_metrics: Whether to compute compute-heavy node retrieval metrics.
+        repair_native_packages: Python packages to rebuild from source inside
+            the container if they fail to import (e.g. AVX-512 wheels on a
+            host without AVX-512). ``None`` disables the repair step.
     Raises:
         ValueError: if the docker build fails
     """
@@ -166,6 +170,9 @@ def evaluate_instance(
 
     # Create a docker container and run the image
     docker_manager.create_container()
+
+    if repair_native_packages:
+        docker_manager.repair_native_imports(packages=repair_native_packages)
 
     # Apply the test patch
     try:
@@ -283,6 +290,7 @@ def evaluate_predictions(
     skip_existing: bool,
     retrieval_metrics_only: bool = False,
     node_retrieval_metrics: bool = False,
+    repair_native_packages: Optional[List[str]] = None,
 ):
     """Predictions file evaluation function.
     Args:
@@ -296,6 +304,10 @@ def evaluate_predictions(
         skip_existing: Whether to skip the existing evaluations in result_path.
         retrieval_metrics_only: Whether to only compute retrieval metrics.
         node_retrieval_metrics: Whether to compute compute-heavy node retrieval metrics.
+        repair_native_packages: Python packages to rebuild from source inside
+            each container if they fail to import. Use this when running on a
+            host whose CPU does not support instructions the pre-built wheels
+            were compiled with (e.g. AVX-512).
     Raises:
         ValueError: If the predictions file is not in the correct format.
     """
@@ -364,6 +376,7 @@ def evaluate_predictions(
                 client=client,
                 retrieval_metrics_only=retrieval_metrics_only,
                 node_retrieval_metrics=node_retrieval_metrics,
+                repair_native_packages=repair_native_packages,
             )
 
         data_gen = dataset_generator(dataset)
@@ -399,8 +412,29 @@ if __name__ == "__main__":
         default=False,
         help="If set, node retrieval metrics will be computed.",
     )
+    parser.add_argument(
+        "--repair-native-imports",
+        nargs="*",
+        default=None,
+        metavar="PACKAGE",
+        help=(
+            "Python packages to rebuild from source inside each container if "
+            "they fail to import. Enable this when pre-built images ship "
+            "CPU-specific wheels that SIGILL on this host (e.g. AVX-512 "
+            "hnswlib on a non-AVX-512 CPU). Pass with no arguments to use the "
+            "default list (hnswlib, chroma-hnswlib), or specify packages "
+            "explicitly: --repair-native-imports hnswlib faiss-cpu."
+        ),
+    )
 
     args = parser.parse_args()
+
+    repair_packages: Optional[List[str]] = None
+    if args.repair_native_imports is not None:
+        repair_packages = args.repair_native_imports or [
+            "hnswlib",
+            "chroma-hnswlib",
+        ]
 
     evaluate_predictions(
         dataset_path=args.dataset_path,
@@ -413,4 +447,5 @@ if __name__ == "__main__":
         skip_existing=args.skip_existing,
         retrieval_metrics_only=args.metrics_only,
         node_retrieval_metrics=args.node_metrics,
+        repair_native_packages=repair_packages,
     )


### PR DESCRIPTION
Pre-built GHCR images for instances depending on chromadb/hnswlib ship AVX-512 wheels that SIGILL on hosts without AVX-512 (e.g. AMD EPYC 7R13), causing F2P tests to crash before they can record a result and giving a false "not resolved" verdict. This was discovered while reproducing a submitter-claimed 66/113 result that we kept measuring as 65/113 on a non-AVX-512 reviewer host.

The new flag adaptively probes each named package inside the running container after pull, and if `import <pkg>` fails, reinstalls from source with `pip install --no-binary=<pkg>`. Default off; passing the flag with no args uses `[hnswlib, chroma-hnswlib]`.

Verified on langchain-ai__langchain-5584: without the flag the instance is unresolved (test_chroma crashes on `import chromadb`), with the flag all 11 tests pass and the iSWE-Agent submission resolves correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
